### PR TITLE
Strict first chunk handling

### DIFF
--- a/fixture
+++ b/fixture
@@ -1,1 +1,0 @@
-unicorn rainbows cake

--- a/index.js
+++ b/index.js
@@ -18,8 +18,8 @@ function FirstChunkStream(options, cb) {
 		throw new Error('FirstChunkStream constructor requires a callback as its second argument.');
 	}
 
-	if ('number' !== typeof options.firstChunkSize) {
-		throw new Error('FirstChunkStream constructor requires options.firstChunkSize to be a number.');
+	if ('number' !== typeof options.chunkLength) {
+		throw new Error('FirstChunkStream constructor requires options.chunkLength to be a number.');
 	}
 
 	if (options.objectMode) {
@@ -45,7 +45,7 @@ function FirstChunkStream(options, cb) {
 	};
 	this.on('error', errorHandler);
 
-	if (1 > options.firstChunkSize) {
+	if (1 > options.chunkLength) {
 		this.__firstChunkSent = true;
 	} else {
 		this.__firstChunkSent = false;
@@ -58,13 +58,13 @@ function FirstChunkStream(options, cb) {
 		if(_this.__firstChunkSent) {
       manager.programPush(chunk, encoding, done);
 		} else {
-			if(chunk.length < options.firstChunkSize - _this.__firstChunkBufferSize) {
+			if(chunk.length < options.chunkLength - _this.__firstChunkBufferSize) {
 				_this.__firstChunkBuffer.push(chunk);
 				_this.__firstChunkBufferSize += chunk.length;
 				done();
 			} else {
-				_this.__firstChunkBuffer.push(chunk.slice(0, options.firstChunkSize - _this.__firstChunkBufferSize));
-				chunk = chunk.slice(options.firstChunkSize - _this.__firstChunkBufferSize);
+				_this.__firstChunkBuffer.push(chunk.slice(0, options.chunkLength - _this.__firstChunkBufferSize));
+				chunk = chunk.slice(options.chunkLength - _this.__firstChunkBufferSize);
 				_this.__firstChunkBufferSize += _this.__firstChunkBuffer[_this.__firstChunkBuffer.length - 1].length;
 				cb(null, Buffer.concat(_this.__firstChunkBuffer), encoding, function(err, buf) {
 					_this.removeListener('error', errorHandler);

--- a/index.js
+++ b/index.js
@@ -80,7 +80,14 @@ function FirstChunkStream(options, cb) {
 
   this.on('finish', function firstChunkStreamFinish() {
 		if(!_this.__firstChunkSent) {
-			cb(new Error('Couldn\'t get the firstChunk!'), Buffer.concat(_this.__firstChunkBuffer));
+			return cb(null, Buffer.concat(_this.__firstChunkBuffer), {}.undef, function(err, buf) {
+				_this.removeListener('error', errorHandler);
+				_this.__firstChunkSent = true;
+				if(buf.length) {
+					manager.programPush(buf, {}.undef, function() {});
+				}
+		    manager.programPush(null, {}.undef, function() {});
+			});
 		}
     manager.programPush(null, {}.undef, function() {});
   });

--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ function FirstChunkStream(options, cb) {
 		throw new Error('FirstChunkStream constructor requires options.firstChunkSize to be a number.');
 	}
 
+	if (options.objectMode) {
+		throw new Error('FirstChunkStream doesn\'t support the objectMode yet.');
+	}
+
 	Duplex.call(this, options);
 
 	manager = createReadStreamBackpressureManager(this);

--- a/index.js
+++ b/index.js
@@ -32,13 +32,6 @@ function FirstChunkStream(options, cb) {
 	Duplex.call(this, options);
 
 	// Initialize the internal state
-	if (1 > options.chunkLength) {
-		_state.sent = true;
-	} else {
-		_state.sent = false;
-	}
-	_state.chunks = [];
-	_state.size = 0;
 	_state.manager = createReadStreamBackpressureManager(this);
 
 	// Errors management

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "cover": "istanbul cover --report html _mocha -- test.js -R spec -t 5000"
   },
   "files": [
     "index.js"
@@ -30,7 +31,9 @@
     "minimum"
   ],
   "devDependencies": {
+    "istanbul": "^0.3.19",
     "mocha": "*",
+    "mocha-lcov-reporter": "0.0.2",
     "streamtest": "^1.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "minimum"
   ],
   "devDependencies": {
-    "concat-stream": "^1.4.5",
-    "mocha": "*"
+    "mocha": "*",
+    "streamtest": "^1.2.1"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,6 @@
 # first-chunk-stream [![Build Status](https://travis-ci.org/sindresorhus/first-chunk-stream.svg?branch=master)](https://travis-ci.org/sindresorhus/first-chunk-stream)
 
-> Transform the first chunk in a stream
-
-Useful if you want to do something to the first chunk.
-
-You can also set the minimum size of that chunk.
-
+> Buffer and transform the n first bytes of a stream
 
 ## Install
 
@@ -22,9 +17,8 @@ var concatStream = require('concat-stream');
 var firstChunkStream = require('first-chunk-stream');
 
 // unicorn.txt => unicorn rainbow
-// `highWaterMark: 1` means it will only read 1 byte at the time
-fs.createReadStream('unicorn.txt', {highWaterMark: 1})
-	.pipe(firstChunkStream({minSize: 7}, function (chunk, enc, cb) {
+fs.createReadStream('unicorn.txt')
+	.pipe(firstChunkStream({firstChunkSize: 7}, function (chunk, enc, cb) {
 		this.push(chunk.toUpperCase());
 		cb();
 	}))
@@ -37,25 +31,29 @@ fs.createReadStream('unicorn.txt', {highWaterMark: 1})
 
 ## API
 
-### firstChunkStream([options], transform)
+### firstChunkStream(options, transform)
 
-#### options.minSize
+Returns a `FirstChunkStream` instance.
+
+#### options
+
+##### options.firstChunkSize
 
 Type: `number`
 
-The minimum size of the first chunk.
+How many bytes you want to buffer.
 
-#### transform(chunk, encoding, callback)
+##### options.*
+
+The options object is also passed to the `Duplex` stream constructor allowing
+ you to customize your stream behavior.
+
+#### transform(err, chunk, encoding, callback)
 
 *Required*  
 Type: `function`
 
-The [function](http://nodejs.org/docs/latest/api/stream.html#stream_transform_transform_chunk_encoding_callback) that gets the first chunk.
-
-### firstChunkStream.ctor()
-
-Instead of returning a [stream.Transform](http://nodejs.org/docs/latest/api/stream.html#stream_class_stream_transform_1) instance, `firstChunk.ctor()` returns a constructor for a custom Transform. This is useful when you want to use the same transform logic in multiple instances.
-
+The function that gets the required `options.firstChunkSize` bytes.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ var firstChunkStream = require('first-chunk-stream');
 
 // unicorn.txt => unicorn rainbow
 fs.createReadStream('unicorn.txt')
-	.pipe(firstChunkStream({firstChunkSize: 7}, function (chunk, enc, cb) {
+	.pipe(firstChunkStream({chunkLength: 7}, function (chunk, enc, cb) {
 		this.push(chunk.toUpperCase());
 		cb();
 	}))
@@ -37,7 +37,7 @@ Returns a `FirstChunkStream` instance.
 
 #### options
 
-##### options.firstChunkSize
+##### options.chunkLength
 
 Type: `number`
 
@@ -53,7 +53,7 @@ The options object is also passed to the `Duplex` stream constructor allowing
 *Required*  
 Type: `function`
 
-The function that gets the required `options.firstChunkSize` bytes.
+The function that gets the required `options.chunkLength` bytes.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,9 @@ fs.createReadStream('unicorn.txt')
 		cb();
 	}))
 	.pipe(concatStream(function (data) {
+		if(data.length < 7) {
+			console.log('Couldn\'t get the minimum required first chunk length.');
+		}
 		console.log(data);
 		//=> UNICORN rainbow
 	}));
@@ -54,6 +57,10 @@ The options object is also passed to the `Duplex` stream constructor allowing
 Type: `function`
 
 The function that gets the required `options.chunkLength` bytes.
+
+Note that the buffer have a smaller length than the required one. In that case,
+ it will be due to the fact the overwhole stream content has a length inferior
+ than the `òptions.chunkLength` value.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,6 @@
 $ npm install --save first-chunk-stream
 ```
 
-
 ## Usage
 
 ```js
@@ -31,6 +30,8 @@ fs.createReadStream('unicorn.txt')
 	}));
 ```
 
+Note this is your responsibility to check if the given first chunk isn't too
+ small than expected.
 
 ## API
 
@@ -58,9 +59,9 @@ Type: `function`
 
 The function that gets the required `options.chunkLength` bytes.
 
-Note that the buffer have a smaller length than the required one. In that case,
- it will be due to the fact the overwhole stream content has a length inferior
- than the `òptions.chunkLength` value.
+Note that the buffer can have a smaller length than the required one. In that
+ case, it will be due to the fact that the overwhole stream content has a length
+ inferior than the `òptions.chunkLength` value.
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -201,6 +201,32 @@ describe('firstChunk()', function () {
 
 			});
 
+			describe('and insufficient content', function () {
+
+				it('should work', function (done) {
+					var callbackCalled = false;
+
+					streamtest[version].fromChunks(['a', 'b', 'c'])
+						.pipe(firstChunkStream({chunkLength: 7}, function (err, chunk, enc, cb) {
+							if(err) {
+								return done(err);
+							}
+							assert.equal(chunk.toString('utf-8'), 'abc');
+							callbackCalled = true;
+							cb(null, new Buffer('b'));
+						}))
+						.pipe(streamtest[version].toText(function (err, text) {
+							if(err) {
+								return done(err);
+							}
+							assert.deepEqual(text, 'b');
+							assert(callbackCalled, 'Callback has been called.');
+							done();
+						}));
+				});
+
+			});
+
 			describe('and changing content', function () {
 
 				it('should work when removing the first chunk', function (done) {

--- a/test.js
+++ b/test.js
@@ -10,50 +10,104 @@ describe('firstChunk()', function () {
 
 		describe('for ' + version + ' streams', function () {
 
-			it('should should work for a single oversized chunk', function (cb) {
-				streamtest[version].fromChunks([content])
-					.pipe(firstChunkStream(function (chunk, enc, cb) {
-						this.push(chunk);
-						cb();
-					}))
-					.pipe(streamtest[version].toText(function (err, text) {
-						if(err) {
-							return done(err);
-						}
-						assert.deepEqual(text, content);
-						cb();
-					}));
+			describe('and leaving content as is', function () {
+
+				it('should work for a single oversized chunk', function (cb) {
+					streamtest[version].fromChunks([content])
+						.pipe(firstChunkStream({firstChunkSize: 7}, function (chunk, enc, cb) {
+							assert.equal(chunk.toString('utf-8'), content.substr(0, 7));
+							cb(null, chunk);
+						}))
+						.pipe(streamtest[version].toText(function (err, text) {
+							if(err) {
+								return done(err);
+							}
+							assert.deepEqual(text, content);
+							cb();
+						}));
+				});
+
+
+				it('should work for required size chunk', function (cb) {
+					streamtest[version].fromChunks([content.substr(0, 7), content.substr(7)])
+						.pipe(firstChunkStream({firstChunkSize: 7}, function (chunk, enc, cb) {
+							assert.equal(chunk.toString('utf-8'), content.substr(0, 7));
+							cb(null, chunk);
+						}))
+						.pipe(streamtest[version].toText(function (err, text) {
+							if(err) {
+								return done(err);
+							}
+							assert.deepEqual(text, content);
+							cb();
+						}));
+				});
+
+				it('should work for several small chunks', function (cb) {
+					streamtest[version].fromChunks(content.split(''))
+						.pipe(firstChunkStream({firstChunkSize: 7}, function (chunk, enc, cb) {
+							assert.equal(chunk.toString('utf-8'), content.substr(0, 7));
+							cb(null, chunk);
+						}))
+						.pipe(streamtest[version].toText(function (err, text) {
+							if(err) {
+								return done(err);
+							}
+							assert.deepEqual(text, content);
+							cb();
+						}));
+				});
+
 			});
 
+			describe('and changing content', function () {
 
-			it('should should work for required size chunk', function (cb) {
-				streamtest[version].fromChunks([content.substr(0, 7), content.substr(7)])
-					.pipe(firstChunkStream({minSize: 7}, function (chunk, enc, cb) {
-						this.push(chunk);
-						cb();
-					}))
-					.pipe(streamtest[version].toText(function (err, text) {
-						if(err) {
-							return done(err);
-						}
-						assert.deepEqual(text, content);
-						cb();
-					}));
-			});
+				it('should work when removing the first chunk', function (cb) {
+					streamtest[version].fromChunks([content])
+						.pipe(firstChunkStream({firstChunkSize: 7}, function (chunk, enc, cb) {
+							assert.equal(chunk.toString('utf-8'), content.substr(0, 7));
+							cb(null, new Buffer(''));
+						}))
+						.pipe(streamtest[version].toText(function (err, text) {
+							if(err) {
+								return done(err);
+							}
+							assert.deepEqual(text, content.substr(8));
+							cb();
+						}));
+				});
 
-			it('should should work for several small chunks', function (cb) {
-				streamtest[version].fromChunks(content.split(''))
-					.pipe(firstChunkStream(function (chunk, enc, cb) {
-						this.push(chunk);
-						cb();
-					}))
-					.pipe(streamtest[version].toText(function (err, text) {
-						if(err) {
-							return done(err);
-						}
-						assert.deepEqual(text, content);
-						cb();
-					}));
+
+				it('should work when replacing per a larger chunk', function (cb) {
+					streamtest[version].fromChunks([content.substr(0, 7), content.substr(7)])
+						.pipe(firstChunkStream({firstChunkSize: 7}, function (chunk, enc, cb) {
+							assert.equal(chunk.toString('utf-8'), content.substr(0, 7));
+							cb(null, Buffer.concat([chunk, new Buffer('plop')], 2));
+						}))
+						.pipe(streamtest[version].toText(function (err, text) {
+							if(err) {
+								return done(err);
+							}
+							assert.deepEqual(text, content.substr(0, 7) + 'plop' + content.substr(8));
+							cb();
+						}));
+				});
+
+				it('should work when replacing per a smaller chunk', function (cb) {
+					streamtest[version].fromChunks(content.split(''))
+						.pipe(firstChunkStream({firstChunkSize: 7}, function (chunk, enc, cb) {
+							assert.equal(chunk.toString('utf-8'), content.substr(0, 7));
+							cb(null, new Buffer('plop'));
+						}))
+						.pipe(streamtest[version].toText(function (err, text) {
+							if(err) {
+								return done(err);
+							}
+							assert.deepEqual(text, 'plop' + content.substr(8));
+							cb();
+						}));
+				});
+
 			});
 
 		});

--- a/test.js
+++ b/test.js
@@ -16,6 +16,15 @@ describe('firstChunk()', function () {
 			});
 		});
 
+		it('when trying to use it in objectMode', function() {
+			assert.throws(function() {
+				firstChunkStream({
+					firstChunkSize: 7,
+					objectMode: true
+				}, function() {});
+			});
+		});
+
 		it('when firstChunk size is bad or missing', function() {
 			assert.throws(function() {
 				firstChunkStream({

--- a/test.js
+++ b/test.js
@@ -130,6 +130,32 @@ describe('firstChunk()', function () {
 
 			});
 
+			describe('and require a 0 length first chunk', function () {
+
+				it('should work', function (done) {
+					var callbackCalled = false;
+
+					streamtest[version].fromChunks([content])
+						.pipe(firstChunkStream({chunkLength: 0}, function (err, chunk, enc, cb) {
+							if(err) {
+								return done(err);
+							}
+							assert.equal(chunk.toString('utf-8'), '');
+							callbackCalled = true;
+							cb(null, new Buffer('popop'));
+						}))
+						.pipe(streamtest[version].toText(function (err, text) {
+							if(err) {
+								return done(err);
+							}
+							assert.deepEqual(text, 'popop' + content);
+							assert(callbackCalled, 'Callback has been called.');
+							done();
+						}));
+				});
+
+			});
+
 			describe('and leaving content as is', function () {
 
 				it('should work for a single oversized chunk', function (done) {

--- a/test.js
+++ b/test.js
@@ -12,10 +12,16 @@ describe('firstChunk()', function () {
 
 			describe('and leaving content as is', function () {
 
-				it('should work for a single oversized chunk', function (cb) {
+				it('should work for a single oversized chunk', function (done) {
+					var callbackCalled = false;
+
 					streamtest[version].fromChunks([content])
-						.pipe(firstChunkStream({firstChunkSize: 7}, function (chunk, enc, cb) {
+						.pipe(firstChunkStream({firstChunkSize: 7}, function (err, chunk, enc, cb) {
+							if(err) {
+								return done(err);
+							}
 							assert.equal(chunk.toString('utf-8'), content.substr(0, 7));
+							callbackCalled = true;
 							cb(null, chunk);
 						}))
 						.pipe(streamtest[version].toText(function (err, text) {
@@ -23,15 +29,22 @@ describe('firstChunk()', function () {
 								return done(err);
 							}
 							assert.deepEqual(text, content);
-							cb();
+							assert(callbackCalled, 'Callback has been called.');
+							done();
 						}));
 				});
 
 
-				it('should work for required size chunk', function (cb) {
+				it('should work for required size chunk', function (done) {
+					var callbackCalled = false;
+
 					streamtest[version].fromChunks([content.substr(0, 7), content.substr(7)])
-						.pipe(firstChunkStream({firstChunkSize: 7}, function (chunk, enc, cb) {
+						.pipe(firstChunkStream({firstChunkSize: 7}, function (err, chunk, enc, cb) {
+							if(err) {
+								return done(err);
+							}
 							assert.equal(chunk.toString('utf-8'), content.substr(0, 7));
+							callbackCalled = true;
 							cb(null, chunk);
 						}))
 						.pipe(streamtest[version].toText(function (err, text) {
@@ -39,14 +52,21 @@ describe('firstChunk()', function () {
 								return done(err);
 							}
 							assert.deepEqual(text, content);
-							cb();
+							assert(callbackCalled, 'Callback has been called.');
+							done();
 						}));
 				});
 
-				it('should work for several small chunks', function (cb) {
+				it('should work for several small chunks', function (done) {
+					var callbackCalled = false;
+
 					streamtest[version].fromChunks(content.split(''))
-						.pipe(firstChunkStream({firstChunkSize: 7}, function (chunk, enc, cb) {
+						.pipe(firstChunkStream({firstChunkSize: 7}, function (err, chunk, enc, cb) {
+							if(err) {
+								return done(err);
+							}
 							assert.equal(chunk.toString('utf-8'), content.substr(0, 7));
+							callbackCalled = true;
 							cb(null, chunk);
 						}))
 						.pipe(streamtest[version].toText(function (err, text) {
@@ -54,7 +74,8 @@ describe('firstChunk()', function () {
 								return done(err);
 							}
 							assert.deepEqual(text, content);
-							cb();
+							assert(callbackCalled, 'Callback has been called.');
+							done();
 						}));
 				});
 
@@ -62,49 +83,70 @@ describe('firstChunk()', function () {
 
 			describe('and changing content', function () {
 
-				it('should work when removing the first chunk', function (cb) {
+				it('should work when removing the first chunk', function (done) {
+					var callbackCalled = false;
+
 					streamtest[version].fromChunks([content])
-						.pipe(firstChunkStream({firstChunkSize: 7}, function (chunk, enc, cb) {
+						.pipe(firstChunkStream({firstChunkSize: 7}, function (err, chunk, enc, cb) {
+							if(err) {
+								return done(err);
+							}
 							assert.equal(chunk.toString('utf-8'), content.substr(0, 7));
-							cb(null, new Buffer(''));
+							callbackCalled = true;
+							cb(null, new Buffer(0));
 						}))
 						.pipe(streamtest[version].toText(function (err, text) {
 							if(err) {
 								return done(err);
 							}
-							assert.deepEqual(text, content.substr(8));
-							cb();
+							assert.deepEqual(text, content.substr(7));
+							assert(callbackCalled, 'Callback has been called.');
+							done();
 						}));
 				});
 
 
-				it('should work when replacing per a larger chunk', function (cb) {
+				it('should work when replacing per a larger chunk', function (done) {
+					var callbackCalled = false;
+
 					streamtest[version].fromChunks([content.substr(0, 7), content.substr(7)])
-						.pipe(firstChunkStream({firstChunkSize: 7}, function (chunk, enc, cb) {
+						.pipe(firstChunkStream({firstChunkSize: 7}, function (err, chunk, enc, cb) {
+							if(err) {
+								return done(err);
+							}
 							assert.equal(chunk.toString('utf-8'), content.substr(0, 7));
-							cb(null, Buffer.concat([chunk, new Buffer('plop')], 2));
+							callbackCalled = true;
+							cb(null, Buffer.concat([chunk, new Buffer('plop')]));
 						}))
 						.pipe(streamtest[version].toText(function (err, text) {
 							if(err) {
 								return done(err);
 							}
-							assert.deepEqual(text, content.substr(0, 7) + 'plop' + content.substr(8));
-							cb();
+							assert.deepEqual(text, content.substr(0, 7) + 'plop' + content.substr(7));
+							assert(callbackCalled, 'Callback has been called.');
+							done();
 						}));
 				});
 
-				it('should work when replacing per a smaller chunk', function (cb) {
+				it('should work when replacing per a smaller chunk', function (done) {
+					var callbackCalled = false;
+
 					streamtest[version].fromChunks(content.split(''))
-						.pipe(firstChunkStream({firstChunkSize: 7}, function (chunk, enc, cb) {
+						.pipe(firstChunkStream({firstChunkSize: 7}, function (err, chunk, enc, cb) {
+							if(err) {
+								return done(err);
+							}
 							assert.equal(chunk.toString('utf-8'), content.substr(0, 7));
+							callbackCalled = true;
 							cb(null, new Buffer('plop'));
 						}))
 						.pipe(streamtest[version].toText(function (err, text) {
 							if(err) {
 								return done(err);
 							}
-							assert.deepEqual(text, 'plop' + content.substr(8));
-							cb();
+							assert.deepEqual(text, 'plop' + content.substr(7));
+							assert(callbackCalled, 'Callback has been called.');
+							done();
 						}));
 				});
 

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ describe('firstChunk()', function () {
 		it('when the callback is not providen', function() {
 			assert.throws(function() {
 				firstChunkStream({
-					firstChunkSize: 7
+					chunkLength: 7
 				});
 			});
 		});
@@ -19,7 +19,7 @@ describe('firstChunk()', function () {
 		it('when trying to use it in objectMode', function() {
 			assert.throws(function() {
 				firstChunkStream({
-					firstChunkSize: 7,
+					chunkLength: 7,
 					objectMode: true
 				}, function() {});
 			});
@@ -28,7 +28,7 @@ describe('firstChunk()', function () {
 		it('when firstChunk size is bad or missing', function() {
 			assert.throws(function() {
 				firstChunkStream({
-					firstChunkSize: 'feferf'
+					chunkLength: 'feferf'
 				}, function() {});
 			});
 			assert.throws(function() {
@@ -46,7 +46,7 @@ describe('firstChunk()', function () {
 
 				it('should report error in the callback before first chunk is sent and allow recovery', function (done) {
 					var callbackCalled = false;
-					var stream = firstChunkStream({firstChunkSize: 7}, function (err, chunk, enc, cb) {
+					var stream = firstChunkStream({chunkLength: 7}, function (err, chunk, enc, cb) {
 						assert.equal(err.message, 'Hey!');
 						assert.equal(chunk.toString('utf-8'), content.substr(0, 2));
 						callbackCalled = true;
@@ -72,7 +72,7 @@ describe('firstChunk()', function () {
 				it('should report error in the callback before first chunk is sent and reemit passed errors', function (done) {
 					var callbackCalled = false;
 					var errEmitted = false;
-					var stream = firstChunkStream({firstChunkSize: 7}, function (err, chunk, enc, cb) {
+					var stream = firstChunkStream({chunkLength: 7}, function (err, chunk, enc, cb) {
 						assert.equal(err.message, 'Hey!');
 						callbackCalled = true;
 						stream.on('error', function(err) {
@@ -102,7 +102,7 @@ describe('firstChunk()', function () {
 				it('should just emit errors when first chunk is sent', function (done) {
 					var callbackCalled = false;
 					var errEmitted = false;
-					var stream = firstChunkStream({firstChunkSize: 7}, function (err, chunk, enc, cb) {
+					var stream = firstChunkStream({chunkLength: 7}, function (err, chunk, enc, cb) {
 						callbackCalled = true;
 						cb(null, chunk);
 					});
@@ -136,7 +136,7 @@ describe('firstChunk()', function () {
 					var callbackCalled = false;
 
 					streamtest[version].fromChunks([content])
-						.pipe(firstChunkStream({firstChunkSize: 7}, function (err, chunk, enc, cb) {
+						.pipe(firstChunkStream({chunkLength: 7}, function (err, chunk, enc, cb) {
 							if(err) {
 								return done(err);
 							}
@@ -159,7 +159,7 @@ describe('firstChunk()', function () {
 					var callbackCalled = false;
 
 					streamtest[version].fromChunks([content.substr(0, 7), content.substr(7)])
-						.pipe(firstChunkStream({firstChunkSize: 7}, function (err, chunk, enc, cb) {
+						.pipe(firstChunkStream({chunkLength: 7}, function (err, chunk, enc, cb) {
 							if(err) {
 								return done(err);
 							}
@@ -181,7 +181,7 @@ describe('firstChunk()', function () {
 					var callbackCalled = false;
 
 					streamtest[version].fromChunks(content.split(''))
-						.pipe(firstChunkStream({firstChunkSize: 7}, function (err, chunk, enc, cb) {
+						.pipe(firstChunkStream({chunkLength: 7}, function (err, chunk, enc, cb) {
 							if(err) {
 								return done(err);
 							}
@@ -207,7 +207,7 @@ describe('firstChunk()', function () {
 					var callbackCalled = false;
 
 					streamtest[version].fromChunks([content])
-						.pipe(firstChunkStream({firstChunkSize: 7}, function (err, chunk, enc, cb) {
+						.pipe(firstChunkStream({chunkLength: 7}, function (err, chunk, enc, cb) {
 							if(err) {
 								return done(err);
 							}
@@ -230,7 +230,7 @@ describe('firstChunk()', function () {
 					var callbackCalled = false;
 
 					streamtest[version].fromChunks([content.substr(0, 7), content.substr(7)])
-						.pipe(firstChunkStream({firstChunkSize: 7}, function (err, chunk, enc, cb) {
+						.pipe(firstChunkStream({chunkLength: 7}, function (err, chunk, enc, cb) {
 							if(err) {
 								return done(err);
 							}
@@ -252,7 +252,7 @@ describe('firstChunk()', function () {
 					var callbackCalled = false;
 
 					streamtest[version].fromChunks(content.split(''))
-						.pipe(firstChunkStream({firstChunkSize: 7}, function (err, chunk, enc, cb) {
+						.pipe(firstChunkStream({chunkLength: 7}, function (err, chunk, enc, cb) {
 							if(err) {
 								return done(err);
 							}


### PR DESCRIPTION
PR according to things discussed here https://github.com/sindresorhus/first-chunk-stream/issues/1

There is still some things to achieve:
- code cleanup + style fixes to fit yours
- behavior if the whole stream content is not large enough to trigger the callback, to me there is 3 options we could:
- \- execute the callback with an error in argument
- \- execute the callback with the buffered content and assume users will check its length to ensure it is the one they expect
- \- simply not execute it
- \- emit an error at the stream level.

I prefer the buffer option since it would allow a BOM strip lib to gracefully handle a file of 1 character without a BOM.
