### PR TITLE
Make the transform function an async function instead of callback-style

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ declare namespace FirstChunkStream {
 		/**
 		How many bytes you want to buffer.
 		*/
-		readonly chunkLength: number;
+		readonly chunkSize: number;
 	}
 
 	type StopSymbol = typeof stop;
@@ -25,9 +25,9 @@ declare class FirstChunkStream extends DuplexStream {
 	Buffer and transform the `n` first bytes of a stream.
 
 	@param options - The options object is passed to the [`Duplex` stream](https://nodejs.org/api/stream.html#stream_class_stream_duplex) constructor allowing you to customize your stream behavior.
-	@param transform - The function that gets the required `options.chunkLength` bytes.
+	@param transform - The function that gets the required `options.chunkSize` bytes.
 
-	Note that the buffer can have a smaller length than the required one. In that case, it will be due to the fact that the complete stream contents has a length less than the `options.chunkLength` value. You should check for this yourself if you strictly depend on the length.
+	Note that the buffer can have a smaller length than the required one. In that case, it will be due to the fact that the complete stream contents has a length less than the `options.chunkSize` value. You should check for this yourself if you strictly depend on the length.
 
 	@example
 	```
@@ -37,7 +37,7 @@ declare class FirstChunkStream extends DuplexStream {
 
 	// unicorn.txt => unicorn rainbow
 	const stream = fs.createReadStream('unicorn.txt')
-		.pipe(new FirstChunkStream({chunkLength: 7}, async (error, chunk, encoding) => {
+		.pipe(new FirstChunkStream({chunkSize: 7}, async (error, chunk, encoding) => {
 			if (error) {
 				throw error;
 			}

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,8 @@ import {
 	DuplexOptions as DuplexStreamOption
 } from 'stream';
 
+declare const stop: unique symbol;
+
 declare namespace FirstChunkStream {
 	interface Options extends Readonly<DuplexStreamOption> {
 		/**
@@ -11,9 +13,11 @@ declare namespace FirstChunkStream {
 		readonly chunkLength: number;
 	}
 
-	type NullableBufferLike = string | Buffer | Uint8Array | void | null;
+	type StopSymbol = typeof stop;
 
-	type TransformFunction = (error: Error | null, chunk: Buffer, encoding: string ) => Promise<NullableBufferLike | {buffer?: NullableBufferLike, encoding?: string}>;
+	type BufferLike = string | Buffer | Uint8Array;
+
+	type TransformFunction = (error: Error | null, chunk: Buffer, encoding: string ) => Promise<StopSymbol | BufferLike | {buffer: BufferLike, encoding?: string}>;
 }
 
 declare class FirstChunkStream extends DuplexStream {
@@ -57,6 +61,8 @@ declare class FirstChunkStream extends DuplexStream {
 		options: FirstChunkStream.Options,
 		transform: FirstChunkStream.TransformFunction
 	);
+
+	static readonly stop: FirstChunkStream.StopSymbol;
 }
 
 export = FirstChunkStream;

--- a/index.d.ts
+++ b/index.d.ts
@@ -58,6 +58,16 @@ declare class FirstChunkStream extends DuplexStream {
 		transform: FirstChunkStream.TransformFunction
 	);
 
+	/**
+	Symbol used to end stream from callback.
+
+	@example
+	```
+	new FirstChunkStream({chunkSize: 7}, async (chunk, encoding) => {
+		return FirstChunkStream.stop;
+	});
+	```
+	*/
 	static readonly stop: FirstChunkStream.StopSymbol;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare namespace FirstChunkStream {
 
 	type BufferLike = string | Buffer | Uint8Array;
 
-	type TransformFunction = (error: Error | null, chunk: Buffer, encoding: string) => Promise<StopSymbol | BufferLike | {buffer: BufferLike, encoding?: string}>;
+	type TransformFunction = (chunk: Buffer, encoding: string) => Promise<StopSymbol | BufferLike | {buffer: BufferLike, encoding?: string}>;
 }
 
 declare class FirstChunkStream extends DuplexStream {
@@ -37,11 +37,7 @@ declare class FirstChunkStream extends DuplexStream {
 
 	// unicorn.txt => unicorn rainbow
 	const stream = fs.createReadStream('unicorn.txt')
-		.pipe(new FirstChunkStream({chunkSize: 7}, async (error, chunk, encoding) => {
-			if (error) {
-				throw error;
-			}
-
+		.pipe(new FirstChunkStream({chunkSize: 7}, async (chunk, encoding) => {
 			return chunk.toString(encoding).toUpperCase();
 		}));
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare namespace FirstChunkStream {
 
 	type BufferLike = string | Buffer | Uint8Array;
 
-	type TransformFunction = (error: Error | null, chunk: Buffer, encoding: string ) => Promise<StopSymbol | BufferLike | {buffer: BufferLike, encoding?: string}>;
+	type TransformFunction = (error: Error | null, chunk: Buffer, encoding: string) => Promise<StopSymbol | BufferLike | {buffer: BufferLike, encoding?: string}>;
 }
 
 declare class FirstChunkStream extends DuplexStream {

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,12 +11,9 @@ declare namespace FirstChunkStream {
 		readonly chunkLength: number;
 	}
 
-	type TransformFunction = (
-		error: Error | null,
-		chunk: Buffer,
-		encoding: string,
-		callback: (error?: Error | null, buffer?: string | Buffer | Uint8Array, encoding?: string) => void
-	) => void;
+	type NullableBufferLike = string | Buffer | Uint8Array | void | null;
+
+	type TransformFunction = (error: Error | null, chunk: Buffer, encoding: string ) => Promise<NullableBufferLike | {buffer?: NullableBufferLike, encoding?: string}>;
 }
 
 declare class FirstChunkStream extends DuplexStream {
@@ -36,13 +33,12 @@ declare class FirstChunkStream extends DuplexStream {
 
 	// unicorn.txt => unicorn rainbow
 	const stream = fs.createReadStream('unicorn.txt')
-		.pipe(new FirstChunkStream({chunkLength: 7}, (error, chunk, encoding, callback) => {
+		.pipe(new FirstChunkStream({chunkLength: 7}, async (error, chunk, encoding) => {
 			if (error) {
-				callback(error);
-				return;
+				throw error;
 			}
 
-			callback(null, chunk.toString(encoding).toUpperCase());
+			return chunk.toString(encoding).toUpperCase();
 		}));
 
 	(async () => {

--- a/index.js
+++ b/index.js
@@ -20,8 +20,8 @@ class FirstChunkStream extends DuplexStream {
 			throw new TypeError('FirstChunkStream constructor requires a callback as its second argument.');
 		}
 
-		if (typeof options.chunkLength !== 'number') {
-			throw new TypeError('FirstChunkStream constructor requires `options.chunkLength` to be a number.');
+		if (typeof options.chunkSize !== 'number') {
+			throw new TypeError('FirstChunkStream constructor requires `options.chunkSize` to be a number.');
 		}
 
 		if (options.objectMode) {
@@ -98,13 +98,13 @@ class FirstChunkStream extends DuplexStream {
 
 			if (state.sent) {
 				state.manager.programPush(chunk, state.encoding, done);
-			} else if (chunk.length < options.chunkLength - state.size) {
+			} else if (chunk.length < options.chunkSize - state.size) {
 				state.chunks.push(chunk);
 				state.size += chunk.length;
 				done();
 			} else {
-				state.chunks.push(chunk.slice(0, options.chunkLength - state.size));
-				chunk = chunk.slice(options.chunkLength - state.size);
+				state.chunks.push(chunk.slice(0, options.chunkSize - state.size));
+				chunk = chunk.slice(options.chunkSize - state.size);
 				state.size += state.chunks[state.chunks.length - 1].length;
 
 				processCallback(null, Buffer.concat(state.chunks, state.size), state.encoding, () => {

--- a/index.js
+++ b/index.js
@@ -71,9 +71,7 @@ class FirstChunkStream extends DuplexStream {
 					return;
 				}
 
-				if (!result) {
-					done();
-				} else if (result === FirstChunkStream.stop) {
+				if (result === FirstChunkStream.stop) {
 					state.manager.programPush(null, undefined, done);
 				} else if (Buffer.isBuffer(result) || (result instanceof Uint8Array) || (typeof result === 'string')) {
 					state.manager.programPush(result, undefined, done);

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ class FirstChunkStream extends DuplexStream {
 
 				let encoding;
 
-				if (typeof buffer !== 'string' && !Buffer.isBuffer(buffer) && !(buffer instanceof Uint8Array)) {
+				if ((typeof buffer !== 'string') && !Buffer.isBuffer(buffer) && !(buffer instanceof Uint8Array)) {
 					encoding = buffer.encoding;
 					buffer = buffer.buffer;
 				}

--- a/index.js
+++ b/index.js
@@ -64,15 +64,15 @@ class FirstChunkStream extends DuplexStream {
 					this.emit('error', error2);
 					stopProcessingError();
 				});
-			}).then(buffer => { // eslint-disable-line promise/prefer-await-to-then
-				if (!buffer) {
+			}).then(result => { // eslint-disable-line promise/prefer-await-to-then
+				if (!result) {
 					done();
-				} else if (buffer === FirstChunkStream.stop) {
+				} else if (result === FirstChunkStream.stop) {
 					state.manager.programPush(null, undefined, done);
-				} else if (Buffer.isBuffer(buffer) || (buffer instanceof Uint8Array) || (typeof buffer === 'string')) {
-					state.manager.programPush(buffer, undefined, done);
+				} else if (Buffer.isBuffer(result) || (result instanceof Uint8Array) || (typeof result === 'string')) {
+					state.manager.programPush(result, undefined, done);
 				} else {
-					state.manager.programPush(buffer.buffer, buffer.encoding, done);
+					state.manager.programPush(result.buffer, result.encoding, done);
 				}
 
 				stopProcessingError();

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 'use strict';
 const {Duplex: DuplexStream} = require('stream');
 
+const stop = Symbol('FirstChunkStream.stop');
+
 class FirstChunkStream extends DuplexStream {
 	constructor(options, callback) {
 		const state = {
@@ -71,7 +73,7 @@ class FirstChunkStream extends DuplexStream {
 					return;
 				}
 
-				if (result === FirstChunkStream.stop) {
+				if (result === stop) {
 					state.manager.programPush(null, undefined, done);
 				} else if (Buffer.isBuffer(result) || (result instanceof Uint8Array) || (typeof result === 'string')) {
 					state.manager.programPush(result, undefined, done);
@@ -173,6 +175,6 @@ function createReadStreamBackpressureManager(readableStream) {
 	return manager;
 }
 
-FirstChunkStream.stop = Symbol('FirstChunkStream.stop');
+FirstChunkStream.stop = stop;
 
 module.exports = FirstChunkStream;

--- a/index.js
+++ b/index.js
@@ -42,8 +42,8 @@ class FirstChunkStream extends DuplexStream {
 				} catch (error) {
 					setImmediate(() => {
 						this.emit('error', error);
+						done();
 					});
-					done();
 					return;
 				}
 

--- a/index.js
+++ b/index.js
@@ -69,15 +69,10 @@ class FirstChunkStream extends DuplexStream {
 					done();
 				} else if (buffer === FirstChunkStream.stop) {
 					state.manager.programPush(null, undefined, done);
+				} else if (Buffer.isBuffer(buffer) || (buffer instanceof Uint8Array) || (typeof buffer === 'string')) {
+					state.manager.programPush(buffer, undefined, done);
 				} else {
-					let encoding;
-
-					if ((typeof buffer !== 'string') && !Buffer.isBuffer(buffer) && !(buffer instanceof Uint8Array)) {
-						encoding = buffer.encoding;
-						buffer = buffer.buffer;
-					}
-
-					state.manager.programPush(buffer, encoding, done);
+					state.manager.programPush(buffer.buffer, buffer.encoding, done);
 				}
 
 				stopProcessingError();

--- a/index.js
+++ b/index.js
@@ -59,12 +59,18 @@ class FirstChunkStream extends DuplexStream {
 				this.emit('errorProcessed');
 			};
 
-			callback(error, buffer, encoding).catch(error2 => {
-				setImmediate(() => {
-					this.emit('error', error2);
-					stopProcessingError();
-				});
-			}).then(result => { // eslint-disable-line promise/prefer-await-to-then
+			(async () => {
+				let result;
+				try {
+					result = await callback(error, buffer, encoding);
+				} catch (error) {
+					setImmediate(() => {
+						this.emit('error', error);
+						stopProcessingError();
+					});
+					return;
+				}
+
 				if (!result) {
 					done();
 				} else if (result === FirstChunkStream.stop) {
@@ -76,7 +82,7 @@ class FirstChunkStream extends DuplexStream {
 				}
 
 				stopProcessingError();
-			});
+			})();
 		};
 
 		// Writes management

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -8,8 +8,7 @@ const options: FirstChunkStream.Options = {chunkSize: 1};
 
 expectError(new FirstChunkStream({}, () => {}));
 
-const firstChunkStream = new FirstChunkStream({chunkSize: 7}, async (error, chunk, encoding) => {
-		expectType<Error | null>(error);
+const firstChunkStream = new FirstChunkStream({chunkSize: 7}, async (chunk, encoding) => {
 		expectType<Buffer>(chunk);
 		expectType<string>(encoding);
 		return '';

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,11 +4,11 @@ import {Duplex} from 'stream';
 import {expectType, expectError} from 'tsd';
 import FirstChunkStream = require('.');
 
-const options: FirstChunkStream.Options = {chunkLength: 1};
+const options: FirstChunkStream.Options = {chunkSize: 1};
 
 expectError(new FirstChunkStream({}, () => {}));
 
-const firstChunkStream = new FirstChunkStream({chunkLength: 7}, async (error, chunk, encoding) => {
+const firstChunkStream = new FirstChunkStream({chunkSize: 7}, async (error, chunk, encoding) => {
 		expectType<Error | null>(error);
 		expectType<Buffer>(chunk);
 		expectType<string>(encoding);
@@ -19,20 +19,20 @@ expectType<Duplex>(firstChunkStream);
 
 fs.createReadStream('unicorn.txt').pipe(firstChunkStream);
 
-expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => FirstChunkStream.stop));
-expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => ''));
-expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => Buffer.from('')));
-expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => 'string'));
-expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => new Uint8Array(0)));
-expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => {
+expectType<FirstChunkStream>(new FirstChunkStream({chunkSize: 7}, async () => FirstChunkStream.stop));
+expectType<FirstChunkStream>(new FirstChunkStream({chunkSize: 7}, async () => ''));
+expectType<FirstChunkStream>(new FirstChunkStream({chunkSize: 7}, async () => Buffer.from('')));
+expectType<FirstChunkStream>(new FirstChunkStream({chunkSize: 7}, async () => 'string'));
+expectType<FirstChunkStream>(new FirstChunkStream({chunkSize: 7}, async () => new Uint8Array(0)));
+expectType<FirstChunkStream>(new FirstChunkStream({chunkSize: 7}, async () => {
 	return {buffer: Buffer.from('')};
 }));
-expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => {
+expectType<FirstChunkStream>(new FirstChunkStream({chunkSize: 7}, async () => {
 	return {buffer: new Uint8Array(0)};
 }));
-expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => {
+expectType<FirstChunkStream>(new FirstChunkStream({chunkSize: 7}, async () => {
 	return {buffer: 'string'};
 }));
-expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => {
+expectType<FirstChunkStream>(new FirstChunkStream({chunkSize: 7}, async () => {
 	return {buffer: 'string', encoding: 'utf8'};
 }));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,38 +6,25 @@ import FirstChunkStream = require('.');
 
 const options: FirstChunkStream.Options = {chunkLength: 1};
 
-expectError(new FirstChunkStream());
 expectError(new FirstChunkStream({}, () => {}));
 
-const firstChunkStream = new FirstChunkStream(
-	{chunkLength: 7},
-	(error, chunk, encoding, callback) => {
+const firstChunkStream = new FirstChunkStream({chunkLength: 7}, async (error, chunk, encoding) => {
 		expectType<Error | null>(error);
 		expectType<Buffer>(chunk);
 		expectType<string>(encoding);
-		expectType<
-			(
-				error?: Error | null,
-				buffer?: string | Buffer | Uint8Array,
-				encoding?: string
-			) => void
-		>(callback);
-
-		callback();
-		callback(null);
-		callback(error);
-		callback(null, chunk.toString(encoding).toUpperCase());
-		callback(null, Buffer.from(chunk.toString(encoding).toUpperCase()));
-		callback(
-			null,
-			new Uint8Array(Buffer.from(chunk.toString(encoding).toUpperCase()))
-		);
-		callback(null, chunk.toString(encoding).toUpperCase(), 'utf8');
-		callback(null, chunk.toString(encoding).toUpperCase(), encoding);
-	}
-);
-
+});
 expectType<FirstChunkStream>(firstChunkStream);
 expectType<Duplex>(firstChunkStream);
 
 fs.createReadStream('unicorn.txt').pipe(firstChunkStream);
+
+expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => null));
+expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => Buffer.from('')));
+expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => 'string'));
+expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => new Uint8Array(0)));
+expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => {buffer: Buffer.from('')}));
+expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => {buffer: new Uint8Array(0)}));
+expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => {buffer: 'string'}));
+expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => {
+	return {buffer: 'string', encoding: 'utf8'};
+}));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -12,19 +12,27 @@ const firstChunkStream = new FirstChunkStream({chunkLength: 7}, async (error, ch
 		expectType<Error | null>(error);
 		expectType<Buffer>(chunk);
 		expectType<string>(encoding);
+		return '';
 });
 expectType<FirstChunkStream>(firstChunkStream);
 expectType<Duplex>(firstChunkStream);
 
 fs.createReadStream('unicorn.txt').pipe(firstChunkStream);
 
-expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => null));
+expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => FirstChunkStream.stop));
+expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => ''));
 expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => Buffer.from('')));
 expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => 'string'));
 expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => new Uint8Array(0)));
-expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => {buffer: Buffer.from('')}));
-expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => {buffer: new Uint8Array(0)}));
-expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => {buffer: 'string'}));
+expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => {
+	return {buffer: Buffer.from('')};
+}));
+expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => {
+	return {buffer: new Uint8Array(0)};
+}));
+expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => {
+	return {buffer: 'string'};
+}));
 expectType<FirstChunkStream>(new FirstChunkStream({chunkLength: 7}, async () => {
 	return {buffer: 'string', encoding: 'utf8'};
 }));

--- a/readme.md
+++ b/readme.md
@@ -19,11 +19,7 @@ import FirstChunkStream = require('first-chunk-stream');
 
 // unicorn.txt => unicorn rainbow
 const stream = fs.createReadStream('unicorn.txt')
-	.pipe(new FirstChunkStream({chunkLength: 7}, async (error, chunk, encoding) => {
-		if (error) {
-			throw error;
-		}
-
+	.pipe(new FirstChunkStream({chunkLength: 7}, async (chunk, encoding) => {
 		return chunk.toString(encoding).toUpperCase();
 	}));
 
@@ -46,7 +42,7 @@ const stream = fs.createReadStream('unicorn.txt')
 
 Returns a `FirstChunkStream` instance.
 
-#### transform(error, chunk, encoding)
+#### transform(chunk, encoding)
 
 Type: `Function`
 

--- a/readme.md
+++ b/readme.md
@@ -13,13 +13,13 @@ $ npm install first-chunk-stream
 ## Usage
 
 ```js
-import * as fs from 'fs';
-import getStream = require('get-stream');
-import FirstChunkStream = require('first-chunk-stream');
+const fs = require('fs');
+const getStream = require('get-stream');
+const FirstChunkStream = require('first-chunk-stream');
 
 // unicorn.txt => unicorn rainbow
 const stream = fs.createReadStream('unicorn.txt')
-	.pipe(new FirstChunkStream({chunkLength: 7}, async (chunk, encoding) => {
+	.pipe(new FirstChunkStream({chunkSize: 7}, async (chunk, encoding) => {
 		return chunk.toString(encoding).toUpperCase();
 	}));
 
@@ -46,9 +46,9 @@ Returns a `FirstChunkStream` instance.
 
 Type: `Function`
 
-Async function that gets the required `options.chunkLength` bytes.
+Async function that gets the required `options.chunkSize` bytes.
 
-Note that the buffer can have a smaller length than the required one. In that case, it will be due to the fact that the complete stream contents has a length less than the `options.chunkLength` value. You should check for this yourself if you strictly depend on the length.
+Note that the buffer can have a smaller length than the required one. In that case, it will be due to the fact that the complete stream contents has a length less than the `options.chunkSize` value. You should check for this yourself if you strictly depend on the length.
 
 #### options
 
@@ -56,7 +56,7 @@ Type: `object`
 
 The options object is passed to the [`Duplex` stream](https://nodejs.org/api/stream.html#stream_class_stream_duplex) constructor allowing you to customize your stream behavior. In addition you can specify the following option:
 
-###### chunkLength
+###### chunkSize
 
 Type: `number`
 

--- a/readme.md
+++ b/readme.md
@@ -13,19 +13,18 @@ $ npm install first-chunk-stream
 ## Usage
 
 ```js
-const fs = require('fs');
-const getStream = require('get-stream');
-const FirstChunkStream = require('first-chunk-stream');
+import * as fs from 'fs';
+import getStream = require('get-stream');
+import FirstChunkStream = require('first-chunk-stream');
 
 // unicorn.txt => unicorn rainbow
 const stream = fs.createReadStream('unicorn.txt')
-	.pipe(new FirstChunkStream({chunkLength: 7}, (error, chunk, encoding, callback) => {
+	.pipe(new FirstChunkStream({chunkLength: 7}, async (error, chunk, encoding) => {
 		if (error) {
-			callback(error);
-			return;
+			throw error;
 		}
 
-		callback(null, chunk.toString(encoding).toUpperCase());
+		return chunk.toString(encoding).toUpperCase();
 	}));
 
 (async () => {
@@ -47,11 +46,11 @@ const stream = fs.createReadStream('unicorn.txt')
 
 Returns a `FirstChunkStream` instance.
 
-#### transform(error, chunk, encoding, callback)
+#### transform(error, chunk, encoding)
 
 Type: `Function`
 
-The function that gets the required `options.chunkLength` bytes.
+Async function that gets the required `options.chunkLength` bytes.
 
 Note that the buffer can have a smaller length than the required one. In that case, it will be due to the fact that the complete stream contents has a length less than the `options.chunkLength` value. You should check for this yourself if you strictly depend on the length.
 

--- a/readme.md
+++ b/readme.md
@@ -38,9 +38,9 @@ const stream = fs.createReadStream('unicorn.txt')
 
 ## API
 
-### firstChunkStream(options, transform)
+### FirstChunkStream(options, transform)
 
-Returns a `FirstChunkStream` instance.
+`FirstChunkStream` constructor.
 
 #### transform(chunk, encoding)
 
@@ -48,7 +48,37 @@ Type: `Function`
 
 Async function that gets the required `options.chunkSize` bytes.
 
+Returns buffer-like object or `string` or object of form {buffer: `Buffer`, encoding: `string`} to send to stream or `firstChunkStream.stop` to end stream right away.
+
+Errors thrown from this function will be emitted as stream errors.
+
 Note that the buffer can have a smaller length than the required one. In that case, it will be due to the fact that the complete stream contents has a length less than the `options.chunkSize` value. You should check for this yourself if you strictly depend on the length.
+
+```
+new FirstChunkStream({chunkSize: 7}, async (chunk, encoding) => {
+	return chunk.toString(encoding).toUpperCase(); // Send string to stream
+});
+
+new FirstChunkStream({chunkSize: 7}, async (chunk, encoding) => {
+	return chunk; // Send buffer to stream
+});
+
+new FirstChunkStream({chunkSize: 7}, async (chunk, encoding) => {
+	return {
+		buffer: chunk,
+		encoding: encoding,
+	}; // Send buffer with encoding to stream
+});
+
+new FirstChunkStream({chunkSize: 7}, async (chunk, encoding) => {
+	return FirstChunkStream.stop; // End the stream
+});
+
+new FirstChunkStream({chunkSize: 7}, async (chunk, encoding) => {
+	throw new Error('Unconditional error'); // Emit stream error
+});
+
+```
 
 #### options
 

--- a/test.js
+++ b/test.js
@@ -39,8 +39,9 @@ streamtest.versions.forEach(version => {
 				(error, chunk, encoding, callback) => {
 					t.is(error.message, 'Hey!');
 					t.is(chunk.toString('utf8'), content.slice(0, 2));
-
-					callback(null, Buffer.from(content.slice(0, 7)));
+					setImmediate(() => {
+						callback(null, Buffer.from(content.slice(0, 7)));
+					});
 				}
 			);
 

--- a/test.js
+++ b/test.js
@@ -13,19 +13,19 @@ test('fails when the options are not provided', t => {
 
 test('fails when the callback is not provided', t => {
 	t.throws(() => {
-		new FirstChunkStream({chunkLength: 7});
+		new FirstChunkStream({chunkSize: 7});
 	});
 });
 
 test('fails when trying to use it in objectMode', t => {
 	t.throws(() => {
-		new FirstChunkStream({chunkLength: 7, objectMode: true}, () => {});
+		new FirstChunkStream({chunkSize: 7, objectMode: true}, () => {});
 	});
 });
 
 test('fails when firstChunk size is bad or missing', t => {
 	t.throws(() => {
-		new FirstChunkStream({chunkLength: 'feferf'}, () => {});
+		new FirstChunkStream({chunkSize: 'feferf'}, () => {});
 	});
 
 	t.throws(() => {
@@ -41,7 +41,7 @@ streamtest.versions.forEach(version => {
 			t.plan(3);
 
 			const stream = new FirstChunkStream(
-				{chunkLength: 7},
+				{chunkSize: 7},
 				async (error, chunk) => {
 					t.is(error.message, 'Hey!');
 					t.is(chunk.toString('utf8'), content.slice(0, 2));
@@ -76,7 +76,7 @@ streamtest.versions.forEach(version => {
 			t.plan(3);
 
 			const stream = new FirstChunkStream(
-				{chunkLength: 7},
+				{chunkSize: 7},
 				async error => {
 					t.is(error.message, 'Hey!');
 
@@ -114,7 +114,7 @@ streamtest.versions.forEach(version => {
 			t.plan(3);
 
 			const stream = new FirstChunkStream(
-				{chunkLength: 7},
+				{chunkSize: 7},
 				async (error, chunk) => {
 					t.pass();
 					return chunk;
@@ -151,7 +151,7 @@ streamtest.versions.forEach(version => {
 			.fromChunks([content])
 			.pipe(
 				new FirstChunkStream(
-					{chunkLength: 0},
+					{chunkSize: 0},
 					async (error, chunk) => {
 						if (error) {
 							t.end(error);
@@ -186,7 +186,7 @@ streamtest.versions.forEach(version => {
 				.fromChunks([content])
 				.pipe(
 					new FirstChunkStream(
-						{chunkLength: 7},
+						{chunkSize: 7},
 						async (error, chunk) => {
 							if (error) {
 								t.end(error);
@@ -222,7 +222,7 @@ streamtest.versions.forEach(version => {
 				.fromChunks([content.slice(0, 7), content.slice(7)])
 				.pipe(
 					new FirstChunkStream(
-						{chunkLength: 7},
+						{chunkSize: 7},
 						async (error, chunk) => {
 							if (error) {
 								t.end(error);
@@ -258,7 +258,7 @@ streamtest.versions.forEach(version => {
 				.fromChunks(content.split(''))
 				.pipe(
 					new FirstChunkStream(
-						{chunkLength: 7},
+						{chunkSize: 7},
 						async (error, chunk) => {
 							if (error) {
 								t.end(error);
@@ -294,7 +294,7 @@ streamtest.versions.forEach(version => {
 
 			const firstChunkStream = inputStream.pipe(
 				new FirstChunkStream(
-					{chunkLength: 7},
+					{chunkSize: 7},
 					async (error, chunk) => {
 						if (error) {
 							t.end(error);
@@ -329,7 +329,7 @@ streamtest.versions.forEach(version => {
 			.fromChunks(['a', 'b', 'c'])
 			.pipe(
 				new FirstChunkStream(
-					{chunkLength: 7},
+					{chunkSize: 7},
 					async (error, chunk) => {
 						if (error) {
 							t.end(error);
@@ -364,7 +364,7 @@ streamtest.versions.forEach(version => {
 				.fromChunks([content])
 				.pipe(
 					new FirstChunkStream(
-						{chunkLength: 7},
+						{chunkSize: 7},
 						async (error, chunk) => {
 							if (error) {
 								t.end(error);
@@ -400,7 +400,7 @@ streamtest.versions.forEach(version => {
 				.fromChunks([content])
 				.pipe(
 					new FirstChunkStream(
-						{chunkLength: 7},
+						{chunkSize: 7},
 						async (error, chunk) => {
 							if (error) {
 								t.end(error);
@@ -435,7 +435,7 @@ streamtest.versions.forEach(version => {
 				.fromChunks([content])
 				.pipe(
 					new FirstChunkStream(
-						{chunkLength: 7},
+						{chunkSize: 7},
 						async (error, chunk) => {
 							if (error) {
 								t.end(error);
@@ -470,7 +470,7 @@ streamtest.versions.forEach(version => {
 				.fromChunks([content.slice(0, 7), content.slice(7)])
 				.pipe(
 					new FirstChunkStream(
-						{chunkLength: 7},
+						{chunkSize: 7},
 						async (error, chunk) => {
 							if (error) {
 								t.end(error);
@@ -506,7 +506,7 @@ streamtest.versions.forEach(version => {
 				.fromChunks(content.split(''))
 				.pipe(
 					new FirstChunkStream(
-						{chunkLength: 7},
+						{chunkSize: 7},
 						async (error, chunk) => {
 							if (error) {
 								t.end(error);

--- a/test.js
+++ b/test.js
@@ -36,12 +36,11 @@ streamtest.versions.forEach(version => {
 
 			const stream = new FirstChunkStream(
 				{chunkLength: 7},
-				(error, chunk, encoding, callback) => {
+				async (error, chunk) => {
 					t.is(error.message, 'Hey!');
 					t.is(chunk.toString('utf8'), content.slice(0, 2));
-					setImmediate(() => {
-						callback(null, Buffer.from(content.slice(0, 7)));
-					});
+
+					return Buffer.from(content.slice(0, 7));
 				}
 			);
 
@@ -72,14 +71,14 @@ streamtest.versions.forEach(version => {
 
 			const stream = new FirstChunkStream(
 				{chunkLength: 7},
-				(error, chunk, encoding, callback) => {
+				async error => {
 					t.is(error.message, 'Hey!');
 
 					stream.on('error', error => {
 						t.is(error.message, 'Ho!');
 					});
 
-					callback(new Error('Ho!'));
+					throw new Error('Ho!');
 				}
 			);
 
@@ -110,10 +109,9 @@ streamtest.versions.forEach(version => {
 
 			const stream = new FirstChunkStream(
 				{chunkLength: 7},
-				(error, chunk, encoding, callback) => {
+				async (error, chunk) => {
 					t.pass();
-
-					callback(null, chunk);
+					return chunk;
 				}
 			);
 
@@ -148,7 +146,7 @@ streamtest.versions.forEach(version => {
 			.pipe(
 				new FirstChunkStream(
 					{chunkLength: 0},
-					(error, chunk, encoding, callback) => {
+					async (error, chunk) => {
 						if (error) {
 							t.end(error);
 							return;
@@ -156,7 +154,7 @@ streamtest.versions.forEach(version => {
 
 						t.is(chunk.toString('utf8'), '');
 
-						callback(null, Buffer.from('popop'));
+						return Buffer.from('popop');
 					}
 				)
 			)
@@ -183,7 +181,7 @@ streamtest.versions.forEach(version => {
 				.pipe(
 					new FirstChunkStream(
 						{chunkLength: 7},
-						(error, chunk, encoding, callback) => {
+						async (error, chunk) => {
 							if (error) {
 								t.end(error);
 								return;
@@ -191,7 +189,7 @@ streamtest.versions.forEach(version => {
 
 							t.is(chunk.toString('utf8'), content.slice(0, 7));
 
-							callback(null, chunk);
+							return chunk;
 						}
 					)
 				)
@@ -219,7 +217,7 @@ streamtest.versions.forEach(version => {
 				.pipe(
 					new FirstChunkStream(
 						{chunkLength: 7},
-						(error, chunk, encoding, callback) => {
+						async (error, chunk) => {
 							if (error) {
 								t.end(error);
 								return;
@@ -227,7 +225,7 @@ streamtest.versions.forEach(version => {
 
 							t.is(chunk.toString('utf8'), content.slice(0, 7));
 
-							callback(null, chunk);
+							return chunk;
 						}
 					)
 				)
@@ -255,7 +253,7 @@ streamtest.versions.forEach(version => {
 				.pipe(
 					new FirstChunkStream(
 						{chunkLength: 7},
-						(error, chunk, encoding, callback) => {
+						async (error, chunk) => {
 							if (error) {
 								t.end(error);
 								return;
@@ -263,7 +261,7 @@ streamtest.versions.forEach(version => {
 
 							t.is(chunk.toString('utf8'), content.slice(0, 7));
 
-							callback(null, chunk);
+							return chunk;
 						}
 					)
 				)
@@ -291,7 +289,7 @@ streamtest.versions.forEach(version => {
 			const firstChunkStream = inputStream.pipe(
 				new FirstChunkStream(
 					{chunkLength: 7},
-					(error, chunk, encoding, callback) => {
+					async (error, chunk) => {
 						if (error) {
 							t.end(error);
 							return;
@@ -311,7 +309,7 @@ streamtest.versions.forEach(version => {
 							})
 						);
 
-						callback(null, chunk);
+						return chunk;
 					}
 				)
 			);
@@ -326,7 +324,7 @@ streamtest.versions.forEach(version => {
 			.pipe(
 				new FirstChunkStream(
 					{chunkLength: 7},
-					(error, chunk, encoding, callback) => {
+					async (error, chunk) => {
 						if (error) {
 							t.end(error);
 							return;
@@ -334,7 +332,7 @@ streamtest.versions.forEach(version => {
 
 						t.is(chunk.toString('utf8'), 'abc');
 
-						callback(null, Buffer.from('b'));
+						return Buffer.from('b');
 					}
 				)
 			)
@@ -361,7 +359,7 @@ streamtest.versions.forEach(version => {
 				.pipe(
 					new FirstChunkStream(
 						{chunkLength: 7},
-						(error, chunk, encoding, callback) => {
+						async (error, chunk) => {
 							if (error) {
 								t.end(error);
 								return;
@@ -369,7 +367,7 @@ streamtest.versions.forEach(version => {
 
 							t.is(chunk.toString('utf8'), content.slice(0, 7));
 
-							callback(null, Buffer.alloc(0));
+							return Buffer.alloc(0);
 						}
 					)
 				)
@@ -397,7 +395,7 @@ streamtest.versions.forEach(version => {
 				.pipe(
 					new FirstChunkStream(
 						{chunkLength: 7},
-						(error, chunk, encoding, callback) => {
+						async (error, chunk) => {
 							if (error) {
 								t.end(error);
 								return;
@@ -405,7 +403,7 @@ streamtest.versions.forEach(version => {
 
 							t.is(chunk.toString('utf8'), content.slice(0, 7));
 
-							callback(null, Buffer.concat([chunk, Buffer.from('plop')]));
+							return Buffer.concat([chunk, Buffer.from('plop')]);
 						}
 					)
 				)
@@ -433,7 +431,7 @@ streamtest.versions.forEach(version => {
 				.pipe(
 					new FirstChunkStream(
 						{chunkLength: 7},
-						(error, chunk, encoding, callback) => {
+						async (error, chunk) => {
 							if (error) {
 								t.end(error);
 								return;
@@ -441,7 +439,7 @@ streamtest.versions.forEach(version => {
 
 							t.is(chunk.toString('utf8'), content.slice(0, 7));
 
-							callback(null, Buffer.from('plop'));
+							return Buffer.from('plop');
 						}
 					)
 				)

--- a/test.js
+++ b/test.js
@@ -5,6 +5,12 @@ import FirstChunkStream from '.';
 const content = 'unicorn rainbows \ncake';
 
 /* eslint-disable no-new */
+test('fails when the options are not provided', t => {
+	t.throws(() => {
+		new FirstChunkStream();
+	});
+});
+
 test('fails when the callback is not provided', t => {
 	t.throws(() => {
 		new FirstChunkStream({chunkLength: 7});
@@ -379,6 +385,76 @@ streamtest.versions.forEach(version => {
 						}
 
 						t.is(text, content.slice(7));
+						t.end();
+					})
+				);
+		}
+	);
+
+	test.cb(
+		`for ${version} streams, works with string and encoding`,
+		t => {
+			t.plan(2);
+
+			streamtest[version]
+				.fromChunks([content])
+				.pipe(
+					new FirstChunkStream(
+						{chunkLength: 7},
+						async (error, chunk) => {
+							if (error) {
+								t.end(error);
+								return;
+							}
+
+							t.is(chunk.toString('utf8'), content.slice(0, 7));
+							return {buffer: chunk.toString('utf8'), encoding: 'utf8'};
+						}
+					)
+				)
+				.pipe(
+					streamtest[version].toText((error, text) => {
+						if (error) {
+							t.end(error);
+							return;
+						}
+
+						t.is(text, content);
+						t.end();
+					})
+				);
+		}
+	);
+
+	test.cb(
+		`for ${version} streams, works with stop`,
+		t => {
+			t.plan(2);
+
+			streamtest[version]
+				.fromChunks([content])
+				.pipe(
+					new FirstChunkStream(
+						{chunkLength: 7},
+						async (error, chunk) => {
+							if (error) {
+								t.end(error);
+								return;
+							}
+
+							t.is(chunk.toString('utf8'), content.slice(0, 7));
+							return FirstChunkStream.stop;
+						}
+					)
+				)
+				.pipe(
+					streamtest[version].toText((error, text) => {
+						if (error) {
+							t.end(error);
+							return;
+						}
+
+						t.is(text, '');
 						t.end();
 					})
 				);


### PR DESCRIPTION
Make the transform function an async function instead of callback-style. (Failing test and fix in first commit, but later on the test isn't needed, as it is caught by existing tests.)

Also fix a bug with processing streams with errors if transform function is not synchronous.

Fixes #6